### PR TITLE
Fix a relative path issue in the boilerplate html

### DIFF
--- a/bodyboilerplate.html
+++ b/bodyboilerplate.html
@@ -3,7 +3,7 @@
 
       <div class="nist-header__logo">
         <a href="https://www.nist.gov/" title="National Institute of Standards and Technology" class="nist-header__logo-link" rel="home">
-          <img src="/nist-header/images/svg/nist_logo_reverse.svg" onerror="this.src='/nist-header/images/nist_logo_reverse.png'" alt="National Institute of Standards and Technology">
+          <img src="https://pages.nist.gov/nist-header/images/svg/nist_logo_reverse.svg" onerror="this.src='https://pages.nist.gov/nist-header/images/nist_logo_reverse.png'" alt="National Institute of Standards and Technology">
         </a>
       </div>
 


### PR DESCRIPTION
The boilerplate didn't include a fully qualified URL so non-pages uses were broken.